### PR TITLE
PL-20248 Added apt-get packages and phantomjs-prebuilt

### DIFF
--- a/cleanroom/Dockerfile
+++ b/cleanroom/Dockerfile
@@ -10,5 +10,12 @@ RUN apt-get update && \
     done && \
     apt-get install --yes $packages
 
+RUN apt-get install --yes php5-cli php5-curl unzip npm nodejs-legacy bundler \
+						apache2-dev fontconfig-config fonts-dejavu-core libapr1 libapr1-dev \
+						libaprutil1 libaprutil1-dev libexpat1-dev libfontconfig1 libfreetype6 \
+  					libldap2-dev libpng12-0 libsctp-dev libsctp1 php5-xdebug uuid-dev
+
+RUN npm install -g phantomjs-prebuilt
+
 COPY cleanroom apt-retry-download /usr/bin/
 WORKDIR /usr/src


### PR DESCRIPTION
@d3ming @kian @obartra 

Minimal first update to cleanroom. Added apt-get dependencies and phantomjs-prebuilt (so we can run the javascript tests on CI again.) 

I'm going to create a separate ticket for figuring out the best way to cache the node_modules (whether that's in the image or mounting a volume on CircleCI.)
